### PR TITLE
dep: opencv 4 introduces error in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ INSTALL_REQUIRES = [
     "Pillow",
     "matplotlib",
     "scikit-image>=0.14.2",
-    "opencv-python-headless",
+    "opencv-python-headless<4",
     "imageio<=2.6.1; python_version<'3.5'",
     "imageio; python_version>='3.5'",
     "Shapely"


### PR DESCRIPTION
Unfortunately opencv 4 introduces errors in the test cases. In the long run it would be better to either

- support both versions
or
- drop support for opencv 3 and rewrite the test cases

